### PR TITLE
fix(cli): Adopt new UX in the messaging for 'platform start'

### DIFF
--- a/pkg/product/strings.go
+++ b/pkg/product/strings.go
@@ -12,7 +12,7 @@ func LoginCmd() string {
 	case licenseapi.DevPodPro:
 		return "devpod login"
 	case licenseapi.VClusterPro:
-		return "vcluster login"
+		return "vcluster platform login"
 	case licenseapi.Loft:
 	}
 


### PR DESCRIPTION
With this fix, now in the `vcluster platform start` messaging it prints:

```
...
Login via CLI: vcluster platform login https://l0i4tv2.loft.host
...
```

instead of the deprecated:

```
...
Login via CLI: vcluster login https://l0i4tv2.loft.host
...
```

#ENG-5956